### PR TITLE
feat: 为双击菜单新增“语种”和“密钥”两个快捷选项

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "me.wjz.nekocrypt"
         minSdk = 26
         targetSdk = 35
-        versionCode = 15    // 唯一版本识别码，每次打包记得+1！！
-        versionName = "1.4.2"
+        versionCode = 16    // 唯一版本识别码，每次打包记得+1！！
+        versionName = "1.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/me/wjz/nekocrypt/service/handler/BaseChatAppHandler.kt
+++ b/app/src/main/java/me/wjz/nekocrypt/service/handler/BaseChatAppHandler.kt
@@ -33,7 +33,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.wjz.nekocrypt.Constant
 import me.wjz.nekocrypt.CryptoMode
+import me.wjz.nekocrypt.NekoCryptApp
 import me.wjz.nekocrypt.R
+import me.wjz.nekocrypt.data.LocalDataStoreManager
 import me.wjz.nekocrypt.ui.component.DecryptionPopup
 import me.wjz.nekocrypt.ui.dialog.AttachmentPreviewState
 import me.wjz.nekocrypt.ui.dialog.AttachmentState
@@ -54,7 +56,6 @@ import me.wjz.nekocrypt.util.isEmpty
 import me.wjz.nekocrypt.util.isFileImage
 import me.wjz.nekocrypt.util.isNodeValid
 import java.io.File
-
 
 // 创建一个CompositionLocal来提供给弹窗
 val LocalFileActionHandler = compositionLocalOf<((NCFileProtocol) -> Unit)?> { null }
@@ -102,7 +103,6 @@ abstract class BaseChatAppHandler : ChatAppHandler {
     // ✨ 2. 只用一个 State 来管理所有UI状态
     private var attachmentState by mutableStateOf(AttachmentState())
 
-
     override fun onAccessibilityEvent(event: AccessibilityEvent, service: MyAccessibilityService) {
         // 悬浮窗管理逻辑
         if (event.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED || event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
@@ -130,7 +130,7 @@ abstract class BaseChatAppHandler : ChatAppHandler {
                 CryptoMode.IMMERSIVE.key -> {
                     if (event.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
 //                        || event.eventType == AccessibilityEvent.TYPE_VIEW_SCROLLED
-                        ) {
+                    ) {
                         //带防抖处理
                         immersiveDecryptionJob?.cancel()
                         // 启动一个新的扫描任务
@@ -228,7 +228,7 @@ abstract class BaseChatAppHandler : ChatAppHandler {
                 )
             }
 
-            val messageNodes = if(cachedMessageListNode == null) findAllTextNodes(root!!) else
+            val messageNodes = if (cachedMessageListNode == null) findAllTextNodes(root!!) else
                 cachedMessageListNode!!.findAccessibilityNodeInfosByViewId(messageTextId)
 
             if (messageNodes.isNullOrEmpty()) {
@@ -236,7 +236,7 @@ abstract class BaseChatAppHandler : ChatAppHandler {
                 // 如果找不到任何消息内容，清空缓存
                 if (immersiveDecryptionCache.isNotEmpty()) {
                     currentService.serviceScope.launch(Dispatchers.Main) {
-                         val managersToDismiss = immersiveDecryptionCache.values.toList()
+                        val managersToDismiss = immersiveDecryptionCache.values.toList()
                         Log.d(tag, "清理 ${managersToDismiss.size} 个残留弹窗。")
                         managersToDismiss.forEach { it.dismiss() }
                     }
@@ -280,7 +280,6 @@ abstract class BaseChatAppHandler : ChatAppHandler {
                 )
                 Log.d(tag, "--------------------------")
             }
-
 
             // 整理完毕，在主线程执行操作
             if (keysToDismiss.isNotEmpty() || updateTasks.isNotEmpty() || creationTasks.isNotEmpty()) {
@@ -384,10 +383,9 @@ abstract class BaseChatAppHandler : ChatAppHandler {
 
                 Log.d(tag, "尝试在根节点 ${rootNode?.className} 中查找发送按钮...")
 
-                sendBtnNode = findSingleNode(rootNode!!,sendBtnId)
+                sendBtnNode = findSingleNode(rootNode!!, sendBtnId)
                 //sendBtnNode = findNodeById(rootNode!!,sendBtnId)
                 cachedSendBtnNode = sendBtnNode
-
             }
 
             // 3. 根据最终的节点状态来决定如何操作
@@ -404,7 +402,7 @@ abstract class BaseChatAppHandler : ChatAppHandler {
                 Log.d(tag, "未找到有效发送按钮节点！")
                 removeOverlayView()
             }
-        }.onFailure { exception ->  Log.e(tag,"handleOverlayManagement错误。${exception.message}") }
+        }.onFailure { exception -> Log.e(tag, "handleOverlayManagement错误。${exception.message}") }
     }
 
     /**
@@ -479,7 +477,7 @@ abstract class BaseChatAppHandler : ChatAppHandler {
                 overlayView?.let {
                     overlayWindowManager?.updateViewLayout(overlayView, getOverlayLayoutParams(rect))
                 }
-                Log.d(tag,"悬浮窗位置修正，修正后位置：$rect")
+                Log.d(tag, "悬浮窗位置修正，修正后位置：$rect")
             } else {
                 overlayWindowManager?.updateViewLayout(overlayView, params)
             }
@@ -507,22 +505,23 @@ abstract class BaseChatAppHandler : ChatAppHandler {
             val root = if (service!!.rootInActiveWindow.isEmpty()) getActiveWindowRoot()
             else currentService.rootInActiveWindow
 
-            val inputNode = findSingleNode(root!!,inputId,Constant.EDIT_TEXT)
+            val inputNode = findSingleNode(root!!, inputId, Constant.EDIT_TEXT)
             val originalText = inputNode?.text?.toString()
 
             // 2. 加密文本
-            val encryptedText =if(originalText!!.containsCiphertext()) originalText else
+            val encryptedText = if (originalText!!.containsCiphertext()) originalText else
                 CryptoManager.encrypt(originalText, currentService.currentKey).applyCiphertextStyle()
 
             // 3. 调用核心发送函数
             setTextAndSend(encryptedText)
-        }.onFailure { exception -> Log.e(tag,"doEncryptAndClick Error${exception.message}") }
+        }.onFailure { exception -> Log.e(tag, "doEncryptAndClick Error${exception.message}") }
     }
+
     // 普通点击的发送逻辑 (用于标准模式的短按)
     protected fun doNormalClick() {
         if (!isNodeValid(cachedSendBtnNode)) {
             val root = service?.rootInActiveWindow ?: return
-            cachedSendBtnNode = findSingleNode(root,sendBtnId)
+            cachedSendBtnNode = findSingleNode(root, sendBtnId)
         }
         cachedSendBtnNode?.performAction(AccessibilityNodeInfo.ACTION_CLICK)
     }
@@ -616,7 +615,7 @@ abstract class BaseChatAppHandler : ChatAppHandler {
 
             // 如果连活跃窗口都没有，就默认返回第一个
             return service!!.rootInActiveWindow
-        }.onFailure { exception ->  Log.e(tag,"getActiveWindowRoot Error:${exception.message}") }
+        }.onFailure { exception -> Log.e(tag, "getActiveWindowRoot Error:${exception.message}") }
         return null
     }
 
@@ -673,16 +672,20 @@ abstract class BaseChatAppHandler : ChatAppHandler {
             onDismissRequest = { sendAttachmentDialogManager = null },
             anchorRect = null
         ) {
-            SendAttachmentDialog(
-                onDismissRequest = { sendAttachmentDialogManager?.dismiss() },
-                onSendRequest = { url ->
-                    // 发送成功后，也关闭对话框
-                    Log.d(tag, "准备发送URL: $url")
-                    setTextAndSend(url)
-                    sendAttachmentDialogManager?.dismiss()
-                },
-                attachmentState = attachmentState
-            )
+            CompositionLocalProvider(
+                LocalDataStoreManager provides NekoCryptApp.instance.dataStoreManager
+            ) {
+                SendAttachmentDialog(
+                    onDismissRequest = { sendAttachmentDialogManager?.dismiss() },
+                    onSendRequest = { url ->
+                        // 发送成功后，也关闭对话框
+                        Log.d(tag, "准备发送URL: $url")
+                        setTextAndSend(url)
+                        sendAttachmentDialogManager?.dismiss()
+                    },
+                    attachmentState = attachmentState
+                )
+            }
         }
         sendAttachmentDialogManager?.show()
     }
@@ -698,9 +701,9 @@ abstract class BaseChatAppHandler : ChatAppHandler {
             Log.d(tag, "service为null！不执行发送！")
             return
         }
-        val root =if(service!!.rootInActiveWindow.isEmpty()) getActiveWindowRoot()
+        val root = if (service!!.rootInActiveWindow.isEmpty()) getActiveWindowRoot()
         else currentService.rootInActiveWindow
-        if(root == null){
+        if (root == null) {
             Log.d(tag, "root为null！不执行发送！")
             return
         }
@@ -783,12 +786,12 @@ abstract class BaseChatAppHandler : ChatAppHandler {
                     )
                 }
 
-
                 // 开始上传，先拿到bytes，拿不到就直接返回。
-                val fileBytes = currentService.contentResolver.openInputStream(uri)?.use { it.readBytes() } ?:return@launch
+                val fileBytes = currentService.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                    ?: return@launch
 
                 // 目前上传接口似乎不支持流式上传。
-                val result : NCFileProtocol = CryptoUploader.upload(
+                val result: NCFileProtocol = CryptoUploader.upload(
                     fileBytes = fileBytes,
                     encryptionKey = currentService.currentKey,
                     fileName = getFileName(uri),
@@ -822,7 +825,10 @@ abstract class BaseChatAppHandler : ChatAppHandler {
 
                 // 4. 上传成功，更新UI
                 updateAttachmentState { currentState ->
-                    currentState.copy(result = result.toEncryptedString(currentService.currentKey), progress = null)
+                    currentState.copy(
+                        result = result.toEncryptedString(currentService.currentKey),
+                        progress = null
+                    )
                 }
                 Log.d(tag, "上传成功，结果: $result")
 
@@ -838,7 +844,7 @@ abstract class BaseChatAppHandler : ChatAppHandler {
                 resetAttachmentState()
             } finally {
                 // 无论文件上传成功与否，如果scheme是file，说明是我们创建的临时文件，删掉
-                if(uri.scheme=="file"){
+                if (uri.scheme == "file") {
                     uri.path?.let { path ->
                         val cacheFile = File(path)
                         if (cacheFile.exists()) {
@@ -862,7 +868,7 @@ abstract class BaseChatAppHandler : ChatAppHandler {
      * @return 如果解密成功，返回明文字符串；否则返回null。
      */
     private fun tryDecryptingText(textToDecrypt: String?): String? {
-        if(textToDecrypt == null)return null
+        if (textToDecrypt == null) return null
         val currentService = service ?: return null
         // 1. 先判断是否真的包含“猫语”，避免不必要的计算
         if (!textToDecrypt.containsCiphertext()) {
@@ -886,7 +892,7 @@ abstract class BaseChatAppHandler : ChatAppHandler {
 
     // 重置附件的状态
     fun resetAttachmentState() {
-        attachmentState= AttachmentState()
+        attachmentState = AttachmentState()
     }
 
     // 更新附件状态

--- a/app/src/main/java/me/wjz/nekocrypt/ui/dialog/AttachmentDialog.kt
+++ b/app/src/main/java/me/wjz/nekocrypt/ui/dialog/AttachmentDialog.kt
@@ -2,15 +2,6 @@ package me.wjz.nekocrypt.ui.dialog
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -19,29 +10,32 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.VpnKey
 import androidx.compose.material.icons.outlined.AttachFile
 import androidx.compose.material.icons.outlined.Collections
 import androidx.compose.material.icons.outlined.FileOpen
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -61,159 +55,198 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import me.wjz.nekocrypt.Constant
 import me.wjz.nekocrypt.R
+import me.wjz.nekocrypt.SettingKeys
+import me.wjz.nekocrypt.data.rememberKeyArrayState
+import me.wjz.nekocrypt.hook.rememberDataStoreState
 import me.wjz.nekocrypt.ui.activity.AttachmentPickerActivity
 import me.wjz.nekocrypt.ui.theme.NekoCryptTheme
+import me.wjz.nekocrypt.util.CiphertextStyleType
 
-// ✨ 1. 将UI状态数据类聚合并定义在这里
 data class AttachmentState(
     var progress: Float? = null,
     var previewInfo: AttachmentPreviewState? = null,
-    var result: String = "", // NCFileProtocol的格式
+    var result: String = "",
 ) {
-    // 计算属性，方便在UI逻辑中使用
-    val isUploading: Boolean get() = progress != null
-    val isUploadFinished: Boolean get() = result.isNotEmpty()
+    val isUploading: Boolean
+        get() = progress != null
+
+    val isUploadFinished: Boolean
+        get() = result.isNotEmpty()
 }
 
-// 预览信息的具体内容
 data class AttachmentPreviewState(
     var uri: Uri,
     var fileName: String,
     var fileSizeFormatted: String,
     var isImage: Boolean,
-    val imageAspectRatio: Float? = null, // 新增：图片的宽高比
+    val imageAspectRatio: Float? = null,
 )
 
-/**
- * ✨ [最终精致版] 发送附件的对话框UI内容
- * 带有动画、进度反馈，并合并了图片/视频选项。
- */
+private enum class MenuPanel {
+    NONE,
+    STYLE,
+    KEY
+}
+
 @Composable
 fun SendAttachmentDialog(
-    // ✨ 2. 接收聚合后的状态对象
     attachmentState: AttachmentState,
     onDismissRequest: () -> Unit,
     onSendRequest: (String) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
+    var activePanel by remember { mutableStateOf(MenuPanel.NONE) }
 
-    var isVisible by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) { isVisible = true }
+    val keysFromDataStore: Array<String> by rememberKeyArrayState()
 
+    var activeKey by rememberDataStoreState(
+        SettingKeys.CURRENT_KEY,
+        Constant.DEFAULT_SECRET_KEY
+    )
 
-    fun dismissWithAnimation() {
+    var ciphertextStyleType by rememberDataStoreState(
+        SettingKeys.CIPHERTEXT_STYLE,
+        CiphertextStyleType.NEKO.toString()
+    )
+
+    val displayKeys = remember(keysFromDataStore, activeKey) {
+        when {
+            keysFromDataStore.isNotEmpty() -> keysFromDataStore.toList()
+            activeKey.isNotBlank() -> listOf(activeKey)
+            else -> listOf(Constant.DEFAULT_SECRET_KEY)
+        }
+    }
+
+    fun dismissDirectly() {
         coroutineScope.launch {
-            isVisible = false
-            delay(300)
+            delay(80)
             onDismissRequest()
         }
     }
 
     NekoCryptTheme(darkTheme = false) {
         Box(modifier = Modifier.padding(8.dp)) {
-            AnimatedVisibility(
-                visible = isVisible,
-                enter = fadeIn(animationSpec = tween(200)) + scaleIn(
-                    animationSpec = spring(
-                        dampingRatio = Spring.DampingRatioLowBouncy,
-                        stiffness = Spring.StiffnessLow
-                    )
+            Card(
+                shape = RoundedCornerShape(24.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface
                 ),
-                exit = fadeOut(animationSpec = tween(300)) + scaleOut(animationSpec = tween(300))
             ) {
-                Card(
-                    shape = RoundedCornerShape(24.dp),
-                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Column(
-                        modifier = Modifier.padding(24.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Text(
-                            text = stringResource(R.string.crypto_attachment_title),
-                            style = MaterialTheme.typography.headlineSmall,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                        Spacer(modifier = Modifier.height(24.dp))
+                    Text(
+                        text = "菜单",
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
 
-                        Box(contentAlignment = Alignment.Center) {
-                            // 封装好的组件，包含图片和文件按钮。
-                            AttachmentOptions(
-                                isUploading = attachmentState.isUploading,
-                                onClicked = { dismissWithAnimation() } // 这里点击关闭对话框，稍后再重新拉起。
-                            )
-                            // 下面就是加载态的圆圈加载
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    Box(contentAlignment = Alignment.Center) {
+                        AttachmentOptions(
+                            isUploading = attachmentState.isUploading,
+                            onDismissAfterPick = { dismissDirectly() },
+                            onStyleClick = {
+                                activePanel =
+                                    if (activePanel == MenuPanel.STYLE) MenuPanel.NONE
+                                    else MenuPanel.STYLE
+                            },
+                            onKeyClick = {
+                                activePanel =
+                                    if (activePanel == MenuPanel.KEY) MenuPanel.NONE
+                                    else MenuPanel.KEY
+                            }
+                        )
+
+                        if (attachmentState.isUploading) {
                             Row(horizontalArrangement = Arrangement.Center) {
-                                AnimatedVisibility(
-                                    visible = attachmentState.isUploading,
-                                    enter = fadeIn(animationSpec = tween(300)),
-                                    exit = fadeOut(animationSpec = tween(200)) + scaleOut(
-                                        animationSpec = tween(
-                                            200
-                                        )
+                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                    CircularProgressIndicator(
+                                        progress = { attachmentState.progress ?: 0f }
                                     )
-                                ) {
-                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                        CircularProgressIndicator(
-                                            progress = { attachmentState.progress ?: 0f }
-                                        )
-                                        Spacer(modifier = Modifier.height(8.dp))
-                                        Text(
-                                            text = stringResource(R.string.crypto_attachment_uploading),
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.primary
-                                        )
-                                    }
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    Text(
+                                        text = stringResource(R.string.crypto_attachment_uploading),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.primary
+                                    )
                                 }
                             }
                         }
+                    }
 
-
+                    if (activePanel != MenuPanel.NONE) {
                         Spacer(modifier = Modifier.height(16.dp))
 
-                        // ✨ 3. 预览区域的逻辑更新
-                        AnimatedVisibility(
-                            // 上传完毕才显示
-                            visible = attachmentState.previewInfo != null && attachmentState.result.isNotEmpty()
-                        ) {
-                            // 使用 rememberUpdatedState 可以在不引起整个对话框重组的情况下更新预览内容
-                            val currentPreview by rememberUpdatedState(attachmentState.previewInfo)
-                            currentPreview?.let {
-                                FilePreview(
-                                    uri = it.uri,
-                                    fileName = it.fileName,
-                                    fileSize = it.fileSizeFormatted,
-                                    isImage = it.isImage,
-                                    aspectRatio = it.imageAspectRatio
+                        when (activePanel) {
+                            MenuPanel.STYLE -> {
+                                InlineSingleChoicePanel(
+                                    title = "语种",
+                                    items = CiphertextStyleType.entries.map {
+                                        it.toString() to stringResource(it.displayNameResId)
+                                    },
+                                    selectedKey = ciphertextStyleType,
+                                    onItemClick = { selected ->
+                                        ciphertextStyleType = selected
+                                    }
                                 )
                             }
+
+                            MenuPanel.KEY -> {
+                                InlineSingleChoicePanel(
+                                    title = "密钥",
+                                    items = displayKeys.map { key -> key to key },
+                                    selectedKey = activeKey,
+                                    onItemClick = { selected ->
+                                        activeKey = selected
+                                    }
+                                )
+                            }
+
+                            MenuPanel.NONE -> Unit
+                        }
+                    }
+
+                    if (attachmentState.previewInfo != null && attachmentState.result.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        val currentPreview by rememberUpdatedState(attachmentState.previewInfo)
+                        currentPreview?.let {
+                            FilePreview(
+                                uri = it.uri,
+                                fileName = it.fileName,
+                                fileSize = it.fileSizeFormatted,
+                                isImage = it.isImage,
+                                aspectRatio = it.imageAspectRatio
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(
+                            onClick = onDismissRequest,
+                            enabled = !attachmentState.isUploading
+                        ) {
+                            Text(stringResource(R.string.cancel))
                         }
 
-                        // ✨ 4. URL输入框已完全移除
+                        Spacer(modifier = Modifier.width(8.dp))
 
-                        Spacer(modifier = Modifier.height(24.dp))
-
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.End
+                        Button(
+                            onClick = { onSendRequest(attachmentState.result) },
+                            enabled = attachmentState.isUploadFinished && !attachmentState.isUploading
                         ) {
-                            // 取消按钮
-                            TextButton(
-                                onClick = { dismissWithAnimation() },
-                                enabled = !attachmentState.isUploading
-                            ) {
-                                Text(stringResource(R.string.cancel))
-                            }
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Button(
-                                // ✨ 发送按钮的可用性也由外部状态决定
-                                onClick = { onSendRequest(attachmentState.result) },
-                                enabled = attachmentState.isUploadFinished && !attachmentState.isUploading
-                            ) {
-                                Text(stringResource(R.string.send))
-                            }
+                            Text(stringResource(R.string.send))
                         }
                     }
                 }
@@ -222,29 +255,28 @@ fun SendAttachmentDialog(
     }
 }
 
-// 文件和图片的预览组件
 @Composable
 fun FilePreview(
     uri: Uri,
     fileName: String,
     fileSize: String,
     isImage: Boolean,
-    aspectRatio: Float?, // 新增宽高比参数
+    aspectRatio: Float?,
 ) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .heightIn(min = 80.dp), // 设置一个最小高度
+            .heightIn(min = 80.dp),
         shape = RoundedCornerShape(16.dp),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)),
+        border = BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
+        ),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(
-                alpha = 0.3f
-            )
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
         )
     ) {
         if (isImage) {
-            // 如果是图片，使用AsyncImage来异步加载并显示
             AsyncImage(
                 model = uri,
                 contentDescription = "Image Preview",
@@ -252,19 +284,16 @@ fun FilePreview(
                     .fillMaxWidth()
                     .heightIn(max = 400.dp)
                     .let {
-                        // ✨ 关键改动：如果宽高比有效，就应用它
                         if (aspectRatio != null && aspectRatio > 0) {
-                            it.aspectRatio(aspectRatio)
+                            it.heightIn(max = 400.dp)
                         } else {
-                            // 否则给一个默认高度
                             it.height(180.dp)
                         }
                     }
                     .clip(RoundedCornerShape(16.dp)),
-                contentScale = ContentScale.Crop // 裁剪图片以填充空间
+                contentScale = ContentScale.Crop
             )
         } else {
-            // 如果是普通文件，显示图标、文件名和大小
             Row(
                 modifier = Modifier.padding(16.dp),
                 verticalAlignment = Alignment.CenterVertically
@@ -275,14 +304,16 @@ fun FilePreview(
                     modifier = Modifier.size(48.dp),
                     tint = MaterialTheme.colorScheme.primary
                 )
+
                 Spacer(modifier = Modifier.width(16.dp))
+
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = fileName,
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Bold,
-                        maxLines = 2, // 最多显示两行
-                        overflow = TextOverflow.Ellipsis // 超出部分显示省略号
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         text = fileSize,
@@ -299,62 +330,149 @@ fun FilePreview(
 private fun AttachmentOptions(
     isUploading: Boolean,
     modifier: Modifier = Modifier,
-    onClicked: () -> Unit,
+    onDismissAfterPick: () -> Unit,
+    onStyleClick: () -> Unit,
+    onKeyClick: () -> Unit,
 ) {
     val context = LocalContext.current
 
-    Row(
+    Column(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        SendOptionItem(
-            icon = Icons.Outlined.Collections,
-            label = stringResource(R.string.crypto_attachment_media),
-            enabled = !isUploading,
-            onClick = {
-//                val intent = Intent(Intent.ACTION_PICK).apply {
-//                    type = "image/* video/*" // 同时选择图片和视频
-//                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-//                }
-//                context.startActivity(intent)
-
-                // 这里体现了两种intent的创建方式，上面的是先弹出一个弹窗，让用户选择其一，再具体拉出对应弹窗，适合service上下文
-
-                // 下面我们这里指定一个activity，就方便很多。
-                val intent = Intent(context, AttachmentPickerActivity::class.java).apply {
-                    // 这里放个extra，activity内部就根据这个额外的kv判断具体拉起逻辑
-                    putExtra(
-                        AttachmentPickerActivity.EXTRA_PICK_TYPE,
-                        AttachmentPickerActivity.TYPE_MEDIA
-                    )
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SendOptionItem(
+                icon = Icons.Outlined.Collections,
+                label = "相册",
+                enabled = !isUploading,
+                onClick = {
+                    val intent = Intent(context, AttachmentPickerActivity::class.java).apply {
+                        putExtra(
+                            AttachmentPickerActivity.EXTRA_PICK_TYPE,
+                            AttachmentPickerActivity.TYPE_MEDIA
+                        )
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    context.startActivity(intent)
+                    onDismissAfterPick()
                 }
-                context.startActivity(intent)
-                onClicked()
-            }
-        )
-        SendOptionItem(
-            icon = Icons.Outlined.FileOpen,
-            label = stringResource(R.string.crypto_attachment_file),
-            enabled = !isUploading,
-            onClick = {
-                val intent = Intent(context, AttachmentPickerActivity::class.java).apply {
-                    putExtra(
-                        AttachmentPickerActivity.EXTRA_PICK_TYPE,
-                        AttachmentPickerActivity.TYPE_FILE
-                    )
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+
+            SendOptionItem(
+                icon = Icons.Outlined.FileOpen,
+                label = "文件",
+                enabled = !isUploading,
+                onClick = {
+                    val intent = Intent(context, AttachmentPickerActivity::class.java).apply {
+                        putExtra(
+                            AttachmentPickerActivity.EXTRA_PICK_TYPE,
+                            AttachmentPickerActivity.TYPE_FILE
+                        )
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    context.startActivity(intent)
+                    onDismissAfterPick()
                 }
-                context.startActivity(intent)
-                onClicked()
-            }
-        )
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SendOptionItem(
+                icon = Icons.Outlined.Translate,
+                label = "语种",
+                enabled = !isUploading,
+                onClick = onStyleClick
+            )
+
+            SendOptionItem(
+                icon = Icons.Filled.VpnKey,
+                label = "密钥",
+                enabled = !isUploading,
+                onClick = onKeyClick
+            )
+        }
     }
 }
 
-/**
- * 对话框里可点击的选项按钮的UI封装
- */
+@Composable
+private fun InlineSingleChoicePanel(
+    title: String,
+    items: List<Pair<String, String>>,
+    selectedKey: String,
+    onItemClick: (String) -> Unit,
+) {
+    val scrollState = rememberScrollState()
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
+        ),
+        border = BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
+        )
+    ) {
+        Column(modifier = Modifier.padding(10.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 300.dp)
+                    .verticalScroll(scrollState),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                items.forEach { (key, label) ->
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable { onItemClick(key) },
+                        shape = RoundedCornerShape(12.dp),
+                        color = if (key == selectedKey) {
+                            MaterialTheme.colorScheme.primaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.surface
+                        }
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 10.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = key == selectedKey,
+                                onClick = { onItemClick(key) },
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = label,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 @Composable
 private fun RowScope.SendOptionItem(
     icon: ImageVector,
@@ -363,8 +481,8 @@ private fun RowScope.SendOptionItem(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
 ) {
-    val alpha by animateFloatAsState(targetValue = if (enabled) 1f else 0.5f, label = "")
     val shape = RoundedCornerShape(12.dp)
+
     Surface(
         modifier = modifier
             .weight(1f)
@@ -374,8 +492,15 @@ private fun RowScope.SendOptionItem(
                 enabled = enabled,
             ),
         shape = shape,
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f * alpha),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.2f * alpha))
+        color = if (enabled) {
+            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        } else {
+            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.25f)
+        },
+        border = BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outline.copy(alpha = if (enabled) 0.2f else 0.1f)
+        )
     ) {
         Column(
             modifier = Modifier.padding(vertical = 16.dp),
@@ -386,13 +511,21 @@ private fun RowScope.SendOptionItem(
                 imageVector = icon,
                 contentDescription = label,
                 modifier = Modifier.size(32.dp),
-                tint = MaterialTheme.colorScheme.primary.copy(alpha = alpha)
+                tint = if (enabled) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
+                }
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = label,
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = alpha)
+                color = if (enabled) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                }
             )
         }
     }

--- a/app/src/main/java/me/wjz/nekocrypt/ui/dialog/AttachmentDialog.kt
+++ b/app/src/main/java/me/wjz/nekocrypt/ui/dialog/AttachmentDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -36,6 +37,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -84,10 +86,11 @@ data class AttachmentPreviewState(
     val imageAspectRatio: Float? = null,
 )
 
-private enum class MenuPanel {
+private enum class MenuContent {
     NONE,
     STYLE,
-    KEY
+    KEY,
+    PREVIEW
 }
 
 @Composable
@@ -97,7 +100,7 @@ fun SendAttachmentDialog(
     onSendRequest: (String) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
-    var activePanel by remember { mutableStateOf(MenuPanel.NONE) }
+    var currentContent by remember { mutableStateOf(MenuContent.NONE) }
 
     val keysFromDataStore: Array<String> by rememberKeyArrayState()
 
@@ -116,6 +119,14 @@ fun SendAttachmentDialog(
             keysFromDataStore.isNotEmpty() -> keysFromDataStore.toList()
             activeKey.isNotBlank() -> listOf(activeKey)
             else -> listOf(Constant.DEFAULT_SECRET_KEY)
+        }
+    }
+
+    LaunchedEffect(attachmentState.previewInfo, attachmentState.result) {
+        if (attachmentState.previewInfo != null && attachmentState.result.isNotEmpty()) {
+            currentContent = MenuContent.PREVIEW
+        } else if (currentContent == MenuContent.PREVIEW) {
+            currentContent = MenuContent.NONE
         }
     }
 
@@ -152,14 +163,14 @@ fun SendAttachmentDialog(
                             isUploading = attachmentState.isUploading,
                             onDismissAfterPick = { dismissDirectly() },
                             onStyleClick = {
-                                activePanel =
-                                    if (activePanel == MenuPanel.STYLE) MenuPanel.NONE
-                                    else MenuPanel.STYLE
+                                currentContent =
+                                    if (currentContent == MenuContent.STYLE) MenuContent.NONE
+                                    else MenuContent.STYLE
                             },
                             onKeyClick = {
-                                activePanel =
-                                    if (activePanel == MenuPanel.KEY) MenuPanel.NONE
-                                    else MenuPanel.KEY
+                                currentContent =
+                                    if (currentContent == MenuContent.KEY) MenuContent.NONE
+                                    else MenuContent.KEY
                             }
                         )
 
@@ -180,11 +191,11 @@ fun SendAttachmentDialog(
                         }
                     }
 
-                    if (activePanel != MenuPanel.NONE) {
+                    if (currentContent != MenuContent.NONE) {
                         Spacer(modifier = Modifier.height(16.dp))
 
-                        when (activePanel) {
-                            MenuPanel.STYLE -> {
+                        when (currentContent) {
+                            MenuContent.STYLE -> {
                                 InlineSingleChoicePanel(
                                     title = "语种",
                                     items = CiphertextStyleType.entries.map {
@@ -197,7 +208,7 @@ fun SendAttachmentDialog(
                                 )
                             }
 
-                            MenuPanel.KEY -> {
+                            MenuContent.KEY -> {
                                 InlineSingleChoicePanel(
                                     title = "密钥",
                                     items = displayKeys.map { key -> key to key },
@@ -208,22 +219,20 @@ fun SendAttachmentDialog(
                                 )
                             }
 
-                            MenuPanel.NONE -> Unit
-                        }
-                    }
+                            MenuContent.PREVIEW -> {
+                                val currentPreview by rememberUpdatedState(attachmentState.previewInfo)
+                                currentPreview?.let {
+                                    FilePreview(
+                                        uri = it.uri,
+                                        fileName = it.fileName,
+                                        fileSize = it.fileSizeFormatted,
+                                        isImage = it.isImage,
+                                        aspectRatio = it.imageAspectRatio
+                                    )
+                                }
+                            }
 
-                    if (attachmentState.previewInfo != null && attachmentState.result.isNotEmpty()) {
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        val currentPreview by rememberUpdatedState(attachmentState.previewInfo)
-                        currentPreview?.let {
-                            FilePreview(
-                                uri = it.uri,
-                                fileName = it.fileName,
-                                fileSize = it.fileSizeFormatted,
-                                isImage = it.isImage,
-                                aspectRatio = it.imageAspectRatio
-                            )
+                            MenuContent.NONE -> Unit
                         }
                     }
 
@@ -284,8 +293,8 @@ fun FilePreview(
                     .fillMaxWidth()
                     .heightIn(max = 400.dp)
                     .let {
-                        if (aspectRatio != null && aspectRatio > 0) {
-                            it.heightIn(max = 400.dp)
+                        if (aspectRatio != null && aspectRatio > 0f) {
+                            it.aspectRatio(aspectRatio)
                         } else {
                             it.height(180.dp)
                         }


### PR DESCRIPTION
## 变更内容

- 将附件弹窗标题由“发送附件”调整为“菜单”
- 保留原有“相册 / 文件”入口
- 新增“语种 / 密钥”两个入口
- “语种”使用 Compose 内置 `Translate` 图标
- “密钥”使用 Compose 内置 `VpnKey` 图标
- 将“语种 / 密钥”配置改为菜单内单选切换，不再额外弹出独立对话框
- 调整菜单内容切换逻辑为互斥显示：
  - 点击“语种”仅显示语种选项
  - 点击“密钥”仅显示密钥选项
  - 上传完成后自动切换为预览区域
- 压缩单选项高度，提高同屏可见数量，改善可用性
- 为悬浮菜单注入 DataStore，上述配置可直接持久化生效

## 交互说明

- 双击输入框打开菜单
- 点击“相册 / 文件”保持原有流程
- 点击“语种 / 密钥”在当前菜单内完成选择
- 不再保留其它展开区域，避免同时显示多个内容块

## 影响范围

- `AttachmentDialog.kt`
- `BaseChatAppHandler.kt`

## 测试通过

- 双击输入框可正常打开菜单
- “语种 / 密钥”可正常切换并持久化
- 菜单在悬浮窗环境下无明显闪烁或卡顿